### PR TITLE
Sprint 9 changes

### DIFF
--- a/styleguide/source/_patterns/02-molecules/wordmark.twig
+++ b/styleguide/source/_patterns/02-molecules/wordmark.twig
@@ -1,4 +1,4 @@
 <div class="joe__wordmark">
-  <h1 class="joe__wordmark__title">{{ wordmark.title }}{% if wordmark.tm %}<sup>&trade;</sup>{% endif %}</h1>
+  <h1 class="joe__wordmark__title">{{ wordmark.title }}{% if wordmark.tm %}<sup>&reg;</sup>{% endif %}</h1>
   <h2 class="joe__wordmark__subtitle">{{ wordmark.subtitle }}</h2>
 </div>

--- a/styleguide/source/_patterns/03-organisms/poll.twig
+++ b/styleguide/source/_patterns/03-organisms/poll.twig
@@ -19,7 +19,7 @@
               <div class="bar" data-max="{{poll.vote_count}}" data-min="0" data-choice="Choice three" data-value="{{answer.vote}}">
                 <div style="width: {{answer.percent}}" class="foreground"></div>
               </div>
-              <div class="percent">{{answer.percent}} ({{answer.vote}} vote)</div>
+              <div class="percent">{{answer.percent}}</div>
             </dd>
           </div>
         </li>

--- a/styleguide/source/_patterns/05-pages/article-listing.json
+++ b/styleguide/source/_patterns/05-pages/article-listing.json
@@ -107,8 +107,8 @@
       "chosen_placeholder": "Choose Article Types",
       "options": [
         { 
-          "value":"CasewithCommentary", 
-          "name":"Case with Commentary" 
+          "value":"CaseandCommentary", 
+          "name":"Case and Commentary" 
         },
         { 
           "value":"MedicalEducation", 
@@ -121,10 +121,6 @@
         { 
           "value":"StateoftheArtandScience", 
           "name":"State of the Art and Science" 
-        },
-        { 
-          "value":"Podcast", 
-          "name":"Podcast" 
         },
         { 
           "value":"HealthLaw", 
@@ -163,24 +159,12 @@
           "name":"AMA Code Says" 
         },
         { 
-          "value":"Peer-reviewedCME", 
-          "name":"Peer-reviewed CME" 
-        },
-        { 
           "value":"OriginalResearch", 
           "name":"Original Research" 
         },
         { 
           "value":"LettertotheEditor", 
           "name":"Letter to the Editor" 
-        },
-        { 
-          "value":"Errata", 
-          "name":"Errata" 
-        },
-        { 
-          "value":"AbouttheContributors", 
-          "name":"About the Contributors" 
         }
       ]
     },

--- a/styleguide/source/_patterns/05-pages/podcast-listing.json
+++ b/styleguide/source/_patterns/05-pages/podcast-listing.json
@@ -95,7 +95,7 @@
     "text": "twitter"
   },
   "page_title": "Podcast",
-  "contentType": "Podcasts",
+  "contentType": "Podcast Episodes",
   "filters": [
     {
       "type": "select",

--- a/styleguide/source/_patterns/05-pages/search-results.json
+++ b/styleguide/source/_patterns/05-pages/search-results.json
@@ -107,8 +107,8 @@
       "chosen_placeholder": "Choose Article Types",
       "options": [
         { 
-          "value":"CasewithCommentary", 
-          "name":"Case with Commentary" 
+          "value":"CaseandCommentary", 
+          "name":"Case and Commentary" 
         },
         { 
           "value":"MedicalEducation", 
@@ -121,10 +121,6 @@
         { 
           "value":"StateoftheArtandScience", 
           "name":"State of the Art and Science" 
-        },
-        { 
-          "value":"Podcast", 
-          "name":"Podcast" 
         },
         { 
           "value":"HealthLaw", 
@@ -163,24 +159,12 @@
           "name":"AMA Code Says" 
         },
         { 
-          "value":"Peer-reviewedCME", 
-          "name":"Peer-reviewed CME" 
-        },
-        { 
           "value":"OriginalResearch", 
           "name":"Original Research" 
         },
         { 
           "value":"LettertotheEditor", 
           "name":"Letter to the Editor" 
-        },
-        { 
-          "value":"Errata", 
-          "name":"Errata" 
-        },
-        { 
-          "value":"AbouttheContributors", 
-          "name":"About the Contributors" 
         }
       ]
     },

--- a/styleguide/source/assets/scss/02-molecules/_author-information.scss
+++ b/styleguide/source/assets/scss/02-molecules/_author-information.scss
@@ -7,7 +7,7 @@
   
   @include breakpoint($bp-med) {
     padding: 0;
-    margin: 85px 0 $gutter;
+    margin: $gutter 0;
   }
 }
 

--- a/styleguide/source/assets/scss/02-molecules/_issue-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_issue-header.scss
@@ -26,15 +26,10 @@
 .joe__issue-header__meta {
   @extend %joe__type--smaller;
   margin-top: 1em;
-  text-align: left;
 }
 
 .joe__issue-header__download {
   @include type($font-serif, .9em, $font-weight-bold, 1.35);
   display: block;
   margin-top: .25em;
-  
-  @include breakpoint($bp-small) {
-    float: right;
-  }
 }

--- a/styleguide/source/assets/scss/02-molecules/_tags-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags-list.scss
@@ -1,7 +1,7 @@
 .joe__tags {
   @extend %joe__type--small;
   position: relative;
-  margin: $gutter 0 ($gutter * 2);
+  margin: $gutter 0;
   padding: 1em 0 0 40px;
 
   border-top: 1px solid $black-20;

--- a/styleguide/source/assets/scss/02-molecules/_wordmark.scss
+++ b/styleguide/source/assets/scss/02-molecules/_wordmark.scss
@@ -12,14 +12,14 @@
 }
 
 .joe__wordmark__title {
-  @include type($font-serif, 1.2em, $font-weight-bolder, 1.3);
+  @include type($font-serif, 1.2em, $font-weight-bold, 1.3);
   margin-bottom: 0;
   margin-top: 0;
   
   sup {
     font-family: $font-sans-serif;
     font-weight: $font-weight-medium;
-    font-size: .75em;
+    font-size: .5em;
   }
   
   .joe__footer & {
@@ -27,11 +27,19 @@
   }
   
   @include breakpoint($bp-small) {
-    @include type($font-serif, 1.55em, $font-weight-bolder, 1.28);
+    @include type($font-serif, 1.55em, $font-weight-bold, 1.28);
     margin-top: 8px;
     
     .joe__footer & {
-      @include type($font-serif, 1.4em, $font-weight-bolder, 1.3);
+      @include type($font-serif, 1.4em, $font-weight-bold, 1.3);
+    }
+  }
+  
+  @include breakpoint($bp-med) {
+    font-weight: $font-weight-bolder;
+    
+    .joe__footer & {
+      font-weight: $font-weight-bolder;
     }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_article-footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_article-footer.scss
@@ -2,7 +2,7 @@
   @extend %joe__type--small;
   background-color: $black-10;
   padding: $gutter-mobile;
-  margin: .5em 0;
+  margin: 0;
   
   .joe__title-label {
     @include type($font-serif, .875em, $font-weight-bold, 1.25);
@@ -16,6 +16,5 @@
   
   @include breakpoint($bp-med) {
     padding: $gutter;
-    margin: 1em 0;
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_article-teaser.scss
+++ b/styleguide/source/assets/scss/03-organisms/_article-teaser.scss
@@ -88,6 +88,7 @@
   @include breakpoint($bp-med) {
     min-width: 35%;
     width: 35%;
+    margin-top: 45px;
     
     .joe__article-teaser--featured & {
       min-width: 45%;

--- a/styleguide/source/assets/scss/03-organisms/_poll.scss
+++ b/styleguide/source/assets/scss/03-organisms/_poll.scss
@@ -70,13 +70,13 @@
   @include breakpoint($bp-med) {
     @include gutter($padding-left-half...);
     display: inline-block;
-    width: 50%;
+    width: 45%;
     float: right;
     margin-top: 0;
   }
   
   @include breakpoint($bp-large) {
-    width: 60%;
+    width: 55%;
   }
 }
 


### PR DESCRIPTION
## Ticket(s)

**Github Issue**

N/A

**Jira Ticket**

N/A

## Description

Completes some style updates from last sprint demo:

- article teaser images have a top margin to align with the title at desktop sizes.
- Trademark is replaced with registered trademark in the footer
- wordmark title was made less bold at mobile/tablet
- the issue detail meta information was centered in the issue detail header.
- Adjust spacing of article information box
- fix up some filter terms
- Removes votes from polls and fixes up the theming a bit for drupal

## To Test
Verify the following changes were made:

- [ ] article teaser images have a top margin to align with the title at desktop sizes.
- [ ] Trademark is replaced with registered trademark in the footer
- [ ] wordmark title was made less bold at mobile/tablet
- [ ] the issue detail meta information was centered in the issue detail header.
- [ ] Adjust spacing of article information box
- [ ] fix up some filter terms
- [ ] Removes votes from polls and fixes up the theming a bit for drupal

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A
