### PR TITLE
Sprint 10 demo changes

### DIFF
--- a/styleguide/source/_patterns/03-organisms/article-tools.twig
+++ b/styleguide/source/_patterns/03-organisms/article-tools.twig
@@ -1,4 +1,4 @@
-<div class="joe__article-tools">
+<div class="joe__article-tools {% if article_tools.pdf == false %}joe__article-tools--no-pdf {% endif %}">
   {% if article_tools.citation %}
     {% set tool_drawer = article_tools.citation.tool_drawer %}
     {% include "@molecules/tool-drawer.twig" %}

--- a/styleguide/source/_patterns/05-pages/article--no-image.json
+++ b/styleguide/source/_patterns/05-pages/article--no-image.json
@@ -128,15 +128,6 @@
         }
       }
     },
-    "pdf": {
-      "button": {
-        "text": "PDF",
-        "type": "link",
-        "href": "/sdsd",
-        "style": "tool",
-        "info": "Download PDF"
-      }
-    },
     "print": {
       "button": {
         "text": "Print",

--- a/styleguide/source/_patterns/05-pages/article-listing.json
+++ b/styleguide/source/_patterns/05-pages/article-listing.json
@@ -489,7 +489,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -514,7 +514,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -536,7 +536,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -562,7 +562,7 @@
         "text":"How Should Physicians Make Decisions about Mandatory Reporting When a Patient Might Become Violent?"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -584,7 +584,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -606,7 +606,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -631,7 +631,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -653,7 +653,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -679,7 +679,7 @@
         "text":"How Should Physicians Make Decisions about Mandatory Reporting When a Patient Might Become Violent?"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -701,7 +701,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     }
   ],

--- a/styleguide/source/_patterns/05-pages/issue-detail.json
+++ b/styleguide/source/_patterns/05-pages/issue-detail.json
@@ -145,7 +145,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -170,7 +170,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -192,7 +192,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -218,7 +218,7 @@
         "text":"How Should Physicians Make Decisions about Mandatory Reporting When a Patient Might Become Violent?"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -240,7 +240,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -262,7 +262,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -287,7 +287,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -309,7 +309,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -335,7 +335,7 @@
         "text":"How Should Physicians Make Decisions about Mandatory Reporting When a Patient Might Become Violent?"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -357,7 +357,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     }
   ],

--- a/styleguide/source/_patterns/05-pages/podcast-listing.json
+++ b/styleguide/source/_patterns/05-pages/podcast-listing.json
@@ -423,9 +423,6 @@
         "class": "joe__article-teaser__title",
         "text":"What are the Health Risks of Global Climate Change?"
       },
-      "image": {
-        "src":"https://ipsumimage.appspot.com/450x225"
-      },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis"
     },
     {
@@ -438,9 +435,6 @@
         "href": "#",
         "class": "joe__article-teaser__title",
         "text":"Bringing “Design Thinking” to Health Care"
-      },
-      "image": {
-        "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis"
     },
@@ -468,9 +462,6 @@
         "class": "joe__article-teaser__title",
         "text":"  What Are Clinicians’ Responsibilities to Incarcerated Patients?"
       },
-      "image": {
-        "src":"https://ipsumimage.appspot.com/450x225"
-      },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis"
     },
     {
@@ -483,9 +474,6 @@
         "href": "#",
         "class": "joe__article-teaser__title",
         "text":"  What Happens When Bad Outcomes Are Unavoidable? Strategies for Communicating Iatrogenic Consequences in Pediatrics"
-      },
-      "image": {
-        "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis"
     },
@@ -500,9 +488,6 @@
         "class": "joe__article-teaser__title",
         "text":"Creating Social and Community Connections for People with Dementia: An Interview with Beth Soltzberg"
       },
-      "image": {
-        "src":"https://ipsumimage.appspot.com/450x225"
-      },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis"
     },
     {
@@ -515,9 +500,6 @@
         "href": "#",
         "class": "joe__article-teaser__title",
         "text":"Strategies for Addressing Moral Distress: An Interview with Dr. Elizabeth Epstein"
-      },
-      "image": {
-        "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis"
     },
@@ -544,9 +526,6 @@
         "href": "#",
         "class": "joe__article-teaser__title",
         "text":"  Rethinking So-Called “Difficult” Patients: An Interview with Dr. Autumn Fiester"
-      },
-      "image": {
-        "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis"
     }

--- a/styleguide/source/_patterns/05-pages/search-results.json
+++ b/styleguide/source/_patterns/05-pages/search-results.json
@@ -489,7 +489,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -514,7 +514,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -536,7 +536,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -562,7 +562,7 @@
         "text":"How Should Physicians Make Decisions about Mandatory Reporting When a Patient Might Become Violent?"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -584,7 +584,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -606,7 +606,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -631,7 +631,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -653,7 +653,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -679,7 +679,7 @@
         "text":"How Should Physicians Make Decisions about Mandatory Reporting When a Patient Might Become Violent?"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -701,7 +701,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     }
   ],

--- a/styleguide/source/_patterns/05-pages/term-listing.json
+++ b/styleguide/source/_patterns/05-pages/term-listing.json
@@ -115,7 +115,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -140,7 +140,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -162,7 +162,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -188,7 +188,7 @@
         "text":"How Should Physicians Make Decisions about Mandatory Reporting When a Patient Might Become Violent?"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -210,7 +210,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -232,7 +232,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -257,7 +257,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -279,7 +279,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -305,7 +305,7 @@
         "text":"How Should Physicians Make Decisions about Mandatory Reporting When a Patient Might Become Violent?"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     },
     {
@@ -327,7 +327,7 @@
         "src":"https://ipsumimage.appspot.com/450x225"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed metus eu dolor euismod porttitor elementum quis erat. Suspendisse ac dolor elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eget condimentum turpis, eget porttitor odio. Mauris pulvinar nisi in laoreet iaculis",
-      "citation": "AMA Journal of Ethics. November 2017, Volume 19, Number 11: 1132-1138.",
+      "citation": "AMA Journal of Ethics. November 2017: 1132-1138.",
       "doi": "10.1001/journalofethics.2017.19.11.msoc1-1711."
     }
   ],

--- a/styleguide/source/assets/scss/02-molecules/_article-tools.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-tools.scss
@@ -33,4 +33,16 @@
       }
     }
   }
+  
+  &.joe__article-tools--no-pdf .joe__tool-drawer .joe__button--tool {
+    right: 52px;
+    
+    @include breakpoint($bp-med) {
+      right: 54px;
+    }
+    
+    @include breakpoint($bp-large) {
+      right: 57px;
+    }
+  }
 }


### PR DESCRIPTION
## Description

Completes some sprint 10 demo changes including:
* Modifying article detail to adjust styles when a PDF is no added (see article--no-image page)
* Removing volume and issue number from the article teasers
* Removing teaser images from all podcast teasers in the podcast listing.


## To Test

- [ ] Spin up patternlab.
- [ ] Review the modified article tools block on the article--no-image page to verify the spacing is correct when the PDF button is no there.
- [ ] Review listing pages (article, search, term, etc.) and verify that the volume and issue numbers are not included in the teaser, but the pages still are.
- [ ] Review the podcast listing page and verify that the teasers there do not have images.



