### PR TITLE
Ewlj 176 browser fixes

### DIFF
--- a/styleguide/source/_patterns/02-molecules/site-search.json
+++ b/styleguide/source/_patterns/02-molecules/site-search.json
@@ -1,7 +1,7 @@
 {
   "search_inputs": [
     {
-      "type": "search",
+      "type": "text",
       "name": "Site Search",
       "id": "site-search",
       "placeholder": "Search"

--- a/styleguide/source/_patterns/02-molecules/wordmark.twig
+++ b/styleguide/source/_patterns/02-molecules/wordmark.twig
@@ -1,4 +1,6 @@
 <div class="joe__wordmark">
-  <h1 class="joe__wordmark__title">{{ wordmark.title }}{% if wordmark.tm %}<sup>&reg;</sup>{% endif %}</h1>
-  <h2 class="joe__wordmark__subtitle">{{ wordmark.subtitle }}</h2>
+  <a href="">
+    <h1 class="joe__wordmark__title">{{ wordmark.title }}{% if wordmark.tm %}<sup>&reg;</sup>{% endif %}</h1>
+    <h2 class="joe__wordmark__subtitle">{{ wordmark.subtitle }}</h2>
+  </a>
 </div>

--- a/styleguide/source/_patterns/04-templates/two-column-left--list.twig
+++ b/styleguide/source/_patterns/04-templates/two-column-left--list.twig
@@ -6,7 +6,7 @@
   {% endblock %}
   <main id="main-content" role="main">
     <div class="container">
-      <article class="joe__layout--two-column-left">
+      <article class="joe__layout--two-column-left is-listing">
         {# Keeping tabindex for accessibility purposes #}
         <div class="joe__page-content joe__page--top" role="article">
           {% block pageContent_header %}

--- a/styleguide/source/assets/scss/00-base/_design-variables.scss
+++ b/styleguide/source/assets/scss/00-base/_design-variables.scss
@@ -1,6 +1,6 @@
 $blue-gradient: linear-gradient(45deg, $navy 0%, $navy-lighter 100%);
-$green-gradient: linear-gradient(45deg, $green-darker 0%, rgba($green-darker, .8) 100%);
-$orange-gradient: linear-gradient(45deg, $orange-darker 0%, $orange 100%);
+$green-gradient: linear-gradient(45deg, $green-darker 0%, rgba($green-darker, .95) 100%);
+$orange-gradient: linear-gradient(45deg, $orange-darker 0%, rgba($orange-darker, .95) 100%);
 $gold-gradient: linear-gradient(45deg, $gold 0%, $orange 100%);
 $white-gradient: linear-gradient(rgba($white, 0%) 0%, $white 100%);
 $shadow: 0 0 5px rgba($black-90, .25);

--- a/styleguide/source/assets/scss/02-molecules/_site-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_site-search.scss
@@ -56,7 +56,8 @@
     }
   }
   
-  input[type="text"] {
+  input[type="text"],
+  input[type="search"] {
     margin: 1em 0;
     border: 0;
     padding-right: 50px;

--- a/styleguide/source/assets/scss/02-molecules/_site-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_site-search.scss
@@ -56,7 +56,7 @@
     }
   }
   
-  input[type="search"] {
+  input[type="text"] {
     margin: 1em 0;
     border: 0;
     padding-right: 50px;

--- a/styleguide/source/assets/scss/02-molecules/_wordmark.scss
+++ b/styleguide/source/assets/scss/02-molecules/_wordmark.scss
@@ -9,6 +9,11 @@
     margin-top: 3px;
     margin-bottom: 10px;
   }
+  
+  a:link,
+  a:visited {
+    color: $black-90;
+  }
 }
 
 .joe__wordmark__title {

--- a/styleguide/source/assets/scss/03-organisms/_cta-band.scss
+++ b/styleguide/source/assets/scss/03-organisms/_cta-band.scss
@@ -23,7 +23,8 @@
     li {
       margin-bottom: 0;
       display: inline-block;
-      float: left;
+      float: flex;
+      overflow: hidden;
       
       // 1-up layout
       // when there is one item it's full width
@@ -79,7 +80,6 @@
     
     .joe__rail-cta {
       margin: 0;
-      height: 100%;
     }
   }
   
@@ -87,7 +87,7 @@
     
     li {
       margin-bottom: 0;
-      display: inline-block;
+      display: flex;
       float: left;
 
       // 4-up layout

--- a/styleguide/source/assets/scss/03-organisms/_poll.scss
+++ b/styleguide/source/assets/scss/03-organisms/_poll.scss
@@ -62,7 +62,7 @@
   @include breakpoint($bp-med) {
     @include gutter($padding-right-half...);
     display: inline-block;
-    width: 47%;
+    width: 46%;
     float: left;
   }
   

--- a/styleguide/source/assets/scss/03-organisms/_poll.scss
+++ b/styleguide/source/assets/scss/03-organisms/_poll.scss
@@ -78,12 +78,14 @@
 }
 
 .joe__poll__answers {
+  margin-top: 1em;
   
   @include breakpoint($bp-med) {
     @include gutter($padding-left-half...);
     display: inline-block;
     width: 45%;
     float: right;
+    margin-top: 0;
   }
   
   @include breakpoint($bp-large) {

--- a/styleguide/source/assets/scss/03-organisms/_related-articles.scss
+++ b/styleguide/source/assets/scss/03-organisms/_related-articles.scss
@@ -1,11 +1,14 @@
 .joe__related-articles {
-  margin: 2em 0;
+  margin: 1em 0;
+  background-color: $white;
+  padding: 0;
   
   @include breakpoint($bp-xs) {
     margin: 2em $gutter-mobile;
   }
   
   @include breakpoint($bp-med) {
-    margin: 4em 0;
+    margin: 2em 0 1em 0;
+    padding: 1em 1.5em;
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_search-page-filters.scss
+++ b/styleguide/source/assets/scss/03-organisms/_search-page-filters.scss
@@ -8,7 +8,6 @@
   
   @include breakpoint($bp-xs) {
     position: relative;
-    width: 100%;
     padding-right: 140px;
     
     input[type='submit'] {

--- a/styleguide/source/assets/scss/03-organisms/_topics.scss
+++ b/styleguide/source/assets/scss/03-organisms/_topics.scss
@@ -23,7 +23,7 @@
   
   @include breakpoint($bp-med) {
     li {
-      width: 50%;
+      width: 47%;
       display: inline-block;
       float: left;
       

--- a/styleguide/source/assets/scss/04-templates/_offset-center.scss
+++ b/styleguide/source/assets/scss/04-templates/_offset-center.scss
@@ -38,10 +38,21 @@
   // Fallback for CSS Grids
   .no-cssgrid & {
     @extend %clearfix;
+    width: 100%;
+    
+    @include breakpoint($bp-small) {
+      display: block;
+      width: 100%;
+    }
+    
+    @include breakpoint($bp-med) {
+      display: block;
+      width: 90%;
+    }
     
     @include breakpoint($bp-large) {
       display: block;
-      width: 100%;
+      width: 90%;
     }
   }
 }// end article

--- a/styleguide/source/assets/scss/04-templates/_two-column-66-33.scss
+++ b/styleguide/source/assets/scss/04-templates/_two-column-66-33.scss
@@ -49,6 +49,7 @@
     grid-column: 1 / 3;
     grid-row: 1;
     -ms-grid-column: 1;
+    -ms-grid-column-span: 2;
     -ms-grid-row: 1;
   }
   
@@ -86,6 +87,7 @@
     grid-column: 3 / 3;
     grid-row: 1;
     -ms-grid-row: 1;
+    -ms-grid-column: 3;
   }
   
   // Flexbox fallback for CSS Grids

--- a/styleguide/source/assets/scss/04-templates/_two-column.scss
+++ b/styleguide/source/assets/scss/04-templates/_two-column.scss
@@ -15,18 +15,6 @@
       -ms-grid-rows: auto auto;
     }
   }
-
-  // Flexbox fallback for CSS Grids
-  .no-cssgrid.flexbox & {
-    display: flex;
-    display: -webkit-flex;
-    flex-direction: column;
-    align-items: stretch;
-    
-    @include breakpoint($bp-small) {
-      flex-direction: row;
-    }
-  }
   
   // Fallback for browsers without css grid or flexbox
   .no-cssgrid.no-flexbox & {
@@ -56,13 +44,6 @@
     
     @include breakpoint($bp-small) {
       width: 50%;
-    }
-  }
-  
-  // Fallback for browsers without css grid or flexbox
-  .no-cssgrid.no-flexbox & {
-    
-    @include breakpoint($bp-small) {
       clear: left;
       display: inline-block;
       float: left;
@@ -92,13 +73,6 @@
     
     @include breakpoint($bp-small) {
       width: 50%;
-    }
-  }
-  
-  // Fallback for browsers without css grid or flexbox
-  .no-cssgrid.no-flexbox & {
-    
-    @include breakpoint($bp-small) {
       clear: right;
       display: inline-block;
       float: right;
@@ -116,7 +90,8 @@
   @include breakpoint($bp-small) {
     grid-column: 1 / 3;
     grid-row: 1;
-    -ms-grid-column: 2;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 2;
     -ms-grid-row: 1;
   }
   
@@ -125,6 +100,7 @@
     grid-row: 1;
     -ms-grid-column: 1;
     -ms-grid-row: 1;
+    -ms-grid-column-span: 1;
   }
   
   // Flexbox fallback for CSS Grids
@@ -132,13 +108,6 @@
     
     @include breakpoint($bp-med) {
       width: 50%;
-    }
-  }
-  
-  // Fallback for browsers without css grid or flexbox
-  .no-cssgrid.no-flexbox & {
-    
-    @include breakpoint($bp-med) {
       clear: left;
       display: inline-block;
       float: left;
@@ -156,13 +125,16 @@
   @include breakpoint($bp-small) {
     grid-column: 1 / 3;
     grid-row: 2;
-    -ms-grid-column: 2;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 2;
     -ms-grid-row: 2;
   }
 
   @include breakpoint($bp-med) {
-    grid-column: 2 / 2;
+    grid-column: 2 / 3;
     grid-row: 1;
+    -ms-grid-column-span: 1;
+    -ms-grid-column: 2;
     -ms-grid-row: 1;
   }
   
@@ -171,13 +143,6 @@
     
     @include breakpoint($bp-med) {
       width: 50%;
-    }
-  }
-  
-  // Fallback for browsers without css grid or flexbox
-  .no-cssgrid.no-flexbox & {
-    
-    @include breakpoint($bp-med) {
       clear: right;
       display: inline-block;
       float: right;

--- a/styleguide/source/assets/scss/04-templates/_two_column-left.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-left.scss
@@ -30,62 +30,143 @@
 }
 
 .joe__page-content {
-  grid-column: 1 / 1;
+  grid-column: 1;
+  grid-row: auto;
   min-width: 0;
   background-color: $white;
   padding-left: $gutter-mobile;
   padding-right: $gutter-mobile;
   padding-top: 1px;
   padding-bottom: 1px;
+  
+  &:nth-of-type(1) {
+    grid-row: 1;
+    -ms-grid-row: 1;
+  }
+  
+  &:nth-of-type(2) {
+    grid-row: 3;
+    -ms-grid-row: 3;
+  }
+  
+  &:nth-of-type(3) {
+    grid-row: 4;
+    -ms-grid-row: 4;
+  }
+  
+  &:nth-of-type(4) {
+    grid-row: 5;
+    -ms-grid-row: 5;
+  }
 
   @include breakpoint($bp-med) {
     @include gutter($margin-right-half...);
     padding-left: $gutter;
     padding-right: $gutter;
-    grid-column: 1 / 2;
-    -ms-grid-column: 1;
+    grid-column: 1;
+    
+    &:nth-of-type(2) {
+      grid-row: 2;
+      -ms-grid-row: 2;
+    }
+    
+    &:nth-of-type(3) {
+      grid-row: 3;
+      -ms-grid-row: 3;
+    }
+    
+    &:nth-of-type(4) {
+      grid-row: 4;
+      -ms-grid-row: 4;
+    }
   }
   
   // Fallback for CSS Grids
   .no-cssgrid & {
+    width: 100%;
+    display: block;
+    float: none;
+    clear: both;
+    
+    @include breakpoint($bp-small) {
+      width: 100%;
+      display: block;
+      float: none;
+      clear: both;
+    }
     
     @include breakpoint($bp-med) {
-      width: 66.66%;
+      width: 63.66%;
       float: left;
+      clear: none;
       display: inline-block;
     }
     
     @include breakpoint($bp-large) {
-      width: 72%;
+      width: 70%;
+      float: left;
+      clear: none;
+      display: inline-block;
     }
   }
 }// end article
 
 .joe__sidebar {
-  grid-column: 1 / 1;
+  grid-column: 1;
+  grid-row: 5;
+  -ms-grid-row: 5;
   min-width: 0;
   margin-left: $gutter-mobile;
   margin-right: $gutter-mobile;
   padding-top: 1px;
   padding-bottom: 1px;
+  
+  .is-listing & {
+    grid-row: 2;
+    -ms-grid-row: 2;
+  }
 
   @include breakpoint($bp-med) {
     @include gutter($margin-left-half...);
     margin-right: 0;
-    grid-column: 2 / 2;
+    grid-column: 2;
+    grid-row: 2;
+    -ms-grid-column: 2;
+    -ms-grid-row: 2;
+    
+    
+    .is-listing & {
+      grid-row: 2;
+      -ms-grid-row: 2;
+    }
   }
   
   // Fallback for CSS Grids
   .no-cssgrid & {
+    width: 100%; 
+    display: block;
+    float: none;
+    clear: both;
+    
+    @include breakpoint($bp-small) {
+      width: 100%; 
+      display: block;
+      float: none;
+      clear: both;
+    }
     
     @include breakpoint($bp-med) {
-      width: 33.33%;
+      width: 31.33%;
       display: inline-block;
-      clear: right;
+      float: right;
+      clear: none;
     }
     
     @include breakpoint($bp-large) {
-      width: 28%;
+      width: 26%;
+      display: inline-block;
+      float: right;
+      clear: none;
     }
   }
 } // end aside.primary
@@ -93,6 +174,8 @@
 .joe__sidebar--top {
   @include breakpoint($bp-med) {
     grid-row: 2;
+    -ms-grid-row: 2;
+    -ms-grid-column: 2;
   }
 }
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

EWLJ-176 Browser Fixes.

## Description

Implements the following out of EWLJ-176:
* Fix all layouts for IE11 and Edge
* Add a conditional class for listing pages with filters (to accommodate layout fix)
* Add some margin to poll answers at mobile breakpoints
* Fix Site search styles to accommodate for a text search input.
* Put rail related articles on a white background for accessibility
* adjust the width of polls for drupal
* add a link to the wordmark and style accordingly
* Fix up some colors (green and orange gradient) for accessibility contrast.
* Adjusts the widths for the 'From the Archive' items.
* Fixes CTA band items so they don't overflow container.


## To Test

- [ ] spin up patternlab and review the above changes.
- [ ] Review all layouts in IE11 & Edge (issue listing, Article, article listing should cover the main layouts)
- [ ] Review that at mobile there is some margin between poll questions and answers
- [ ] Verify site search styles now accommodate text inputs
- [ ] Verify rail realted articles now has a white background (podcast detail)
- [ ] verify the wordmark is now a link. 


## Remaining Tasks

- Update Drupal CSS
- For Listing pages with filters (Podcast, articles, ethics cases, search, etc.) Add in the 'is-listing' class as shown in this PR (captured in ticket EWLJ-194)
