### PR TITLE
remove active link state from wordmark in the navigation

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_wordmark.scss
+++ b/styleguide/source/assets/scss/02-molecules/_wordmark.scss
@@ -14,6 +14,12 @@
   a:visited {
     color: $black-90;
   }
+  
+  a:active,
+  a:hover,
+  a:focus {
+    text-decoration: none;
+  }
 }
 
 .joe__wordmark__title {


### PR DESCRIPTION
## Description

From bugfix spreadsheet:

Remove the active state from the wordmark link in the main navigation.


## To Test

- [ ] Spin up patternlab
- [ ] Visit any page and verify that the wordmark in the navigation does not have an active state.

After this is merged in I can run a deploy for drupal.